### PR TITLE
Tern [docs] now opens on new windows

### DIFF
--- a/addon/tern/tern.js
+++ b/addon/tern/tern.js
@@ -222,7 +222,9 @@ define(['lib/codemirror/lib/codemirror'], function(CodeMirror) {
           tip.appendChild(document.createTextNode(" — " + data.doc));
         if (data.url) {
           tip.appendChild(document.createTextNode(" "));
-          tip.appendChild(elt("a", null, "[docs]")).href = data.url;
+          var docsBtn = elt("a", null, "[docs]");
+          docsBtn.target = "_blank";
+          tip.appendChild(docsBtn).href = data.url;
         }
       }
       tempTooltip(cm, tip);


### PR DESCRIPTION
Tern의 도움말 팝업에서 [docs] 버튼을 클릭했을 때 도움말이 새 창에 뜨도록 수정하였습니다

http://172.21.17.25/redmine/issues/10500
