### PR TITLE
문자열/코멘트 작성시 인덴트 변경 안되도록 수정

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -2111,6 +2111,7 @@ define(function() {
     var ch = String.fromCharCode(charCode == null ? keyCode : charCode);
     if (this.options.electricChars && this.doc.mode.electricChars &&
         this.options.smartIndent && !isReadOnly(this) &&
+        (!this.doc.mode.checkElectric || this.doc.mode.checkElectric(cm)) &&
         this.doc.mode.electricChars.indexOf(ch) > -1)
       setTimeout(operation(cm, function() {indentLine(cm, cm.doc.sel.to.line, "smart");}), 75);
     if (handleCharBinding(cm, e, ch)) return;

--- a/mode/javascript/javascript.js
+++ b/mode/javascript/javascript.js
@@ -461,6 +461,10 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
     },
 
     electricChars: ":{}",
+    checkElectric: function(cm) {
+      var tokenType = cm.getTokenTypeAt(cm.getCursor("head"));
+      return (tokenType !== "string" && tokenType !== "comment");
+    },
     blockCommentStart: jsonMode ? null : "/*",
     blockCommentEnd: jsonMode ? null : "*/",
     lineComment: jsonMode ? null : "//",


### PR DESCRIPTION
자바스크립트 파일 편집시, "{}:" 키가 입력되면 해당 라인의 indentation이 재조정되는데, 문자열이나 코멘트 작성시에는 이 기능이 동작하지 않도록 수정하였습니다

관련 이슈: http://172.21.17.25/redmine/issues/10317
